### PR TITLE
Add diagram to WebPublisher sample

### DIFF
--- a/ModelContextProtocol.slnx
+++ b/ModelContextProtocol.slnx
@@ -14,6 +14,7 @@
     <Project Path="samples/EverythingServer/EverythingServer.csproj" />
     <Project Path="samples/QuickstartClient/QuickstartClient.csproj" />
     <Project Path="samples/QuickstartWeatherServer/QuickstartWeatherServer.csproj" />
+    <Project Path="samples/WebPublisher/WebPublisher.csproj" />
     <Project Path="samples/TestServerWithHosting/TestServerWithHosting.csproj" />
   </Folder>
   <Folder Name="/Solution Items/">

--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ Console.WriteLine(result.Content.First(c => c.Type == "text").Text);
 
 You can find samples demonstrating how to use ModelContextProtocol with an LLM SDK in the [samples](samples) directory, and also refer to the [tests](tests/ModelContextProtocol.Tests) project for more examples. Additional examples and documentation will be added as in the near future.
 
+Some notable samples include:
+- **WebPublisher** – a minimal ASP.NET application that copies files from a development directory to a production directory through a simple web form. The default page displays a diagram showing the publishing flow.
+
 Clients can connect to any MCP server, not just ones created using this library. The protocol is designed to be server-agnostic, so you can use this library to connect to any compliant server.
 
 Tools can be easily exposed for immediate use by `IChatClient`s, because `McpClientTool` inherits from `AIFunction`.

--- a/samples/WebPublisher/Pages/Index.cshtml
+++ b/samples/WebPublisher/Pages/Index.cshtml
@@ -1,0 +1,30 @@
+@page
+@model IndexModel
+@{
+    ViewData["Title"] = "Publisher";
+}
+<h1>Captivate Publisher</h1>
+<img src="~/images/publish_flow.svg" alt="Publishing flow" style="display:block;margin-bottom:20px;max-width:400px;" />
+<form id="publishForm">
+    <label>Development Directory:</label>
+    <input type="text" id="source" name="sourceDir" style="width:300px" />
+    <br/>
+    <label>Production Directory:</label>
+    <input type="text" id="target" name="targetDir" style="width:300px" />
+    <br/>
+    <button type="submit">Publish</button>
+</form>
+<pre id="result"></pre>
+@section Scripts {
+<script>
+ document.getElementById('publishForm').addEventListener('submit', async function(e) {
+     e.preventDefault();
+     const formData = new FormData(e.target);
+     const response = await fetch('/publish', {
+         method: 'POST',
+         body: new URLSearchParams(formData)
+     });
+     document.getElementById('result').textContent = await response.text();
+ });
+</script>
+}

--- a/samples/WebPublisher/Pages/Index.cshtml.cs
+++ b/samples/WebPublisher/Pages/Index.cshtml.cs
@@ -1,0 +1,10 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace WebPublisher.Pages;
+
+public class IndexModel : PageModel
+{
+    public void OnGet()
+    {
+    }
+}

--- a/samples/WebPublisher/Pages/Shared/_Layout.cshtml
+++ b/samples/WebPublisher/Pages/Shared/_Layout.cshtml
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>@ViewData["Title"] - Captivate Publisher</title>
+    <style>
+        body { font-family: sans-serif; margin: 40px; }
+        .container { max-width: 600px; margin: auto; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        @RenderBody()
+    </div>
+    @RenderSection("Scripts", required: false)
+</body>
+</html>

--- a/samples/WebPublisher/Pages/_ViewImports.cshtml
+++ b/samples/WebPublisher/Pages/_ViewImports.cshtml
@@ -1,0 +1,2 @@
+@using WebPublisher.Pages
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/samples/WebPublisher/Pages/_ViewStart.cshtml
+++ b/samples/WebPublisher/Pages/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+@{
+    Layout = "_Layout";
+}

--- a/samples/WebPublisher/Program.cs
+++ b/samples/WebPublisher/Program.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using System.IO;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddRazorPages();
+
+var app = builder.Build();
+
+app.UseStaticFiles();
+app.MapRazorPages();
+
+app.MapPost("/publish", (string sourceDir, string targetDir) =>
+{
+    if (!Directory.Exists(sourceDir))
+    {
+        return Results.BadRequest($"Source directory '{sourceDir}' does not exist.");
+    }
+
+    if (!Directory.Exists(targetDir))
+    {
+        Directory.CreateDirectory(targetDir);
+    }
+
+    foreach (var file in Directory.GetFiles(sourceDir, "*", SearchOption.AllDirectories))
+    {
+        var relativePath = Path.GetRelativePath(sourceDir, file);
+        var targetPath = Path.Combine(targetDir, relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
+        System.IO.File.Copy(file, targetPath, true);
+    }
+
+    return Results.Ok($"Files copied from {sourceDir} to {targetDir}");
+});
+
+app.Run();

--- a/samples/WebPublisher/WebPublisher.csproj
+++ b/samples/WebPublisher/WebPublisher.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/samples/WebPublisher/wwwroot/images/publish_flow.svg
+++ b/samples/WebPublisher/wwwroot/images/publish_flow.svg
@@ -1,0 +1,12 @@
+<svg width="400" height="200" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="5" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#333" />
+    </marker>
+  </defs>
+  <rect x="10" y="60" width="120" height="80" fill="#f0f0f0" stroke="#333" />
+  <text x="70" y="105" text-anchor="middle" font-family="sans-serif" font-size="16">Dev</text>
+  <rect x="270" y="60" width="120" height="80" fill="#f0f0f0" stroke="#333" />
+  <text x="330" y="105" text-anchor="middle" font-family="sans-serif" font-size="16">Prod</text>
+  <path d="M130 100 L270 100" stroke="#333" stroke-width="2" marker-end="url(#arrow)" />
+</svg>


### PR DESCRIPTION
## Summary
- add small directory publishing diagram used by WebPublisher
- display diagram above the publish form
- improve layout styling

## Testing
- `dotnet build samples/WebPublisher/WebPublisher.csproj -nologo` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6861684c0694832ebd249daf76ac7407